### PR TITLE
Add `debian` package to be able to use deb822_repository.

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,8 +141,7 @@ Options passed to `kubeadm init` when initializing the Kubernetes control plane.
 
 ```yaml
 kubernetes_apt_release_channel: "stable"
-kubernetes_apt_keyring_file: "/etc/apt/keyrings/kubernetes-apt-keyring.asc"
-kubernetes_apt_repository: "deb [signed-by={{ kubernetes_apt_keyring_file }}] https://pkgs.k8s.io/core:/{{ kubernetes_apt_release_channel }}:/v{{ kubernetes_version }}/deb/ /"
+kubernetes_apt_repository: "https://pkgs.k8s.io/core:/{{ kubernetes_apt_release_channel }}:/v{{ kubernetes_version }}/deb/"
 ```
 
 Apt repository options for Kubernetes installation.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -56,8 +56,7 @@ kubernetes_version_kubeadm: 'stable-{{ kubernetes_version }}'
 kubernetes_ignore_preflight_errors: 'all'
 
 kubernetes_apt_release_channel: "stable"
-kubernetes_apt_keyring_file: "/etc/apt/keyrings/kubernetes-apt-keyring.asc"
-kubernetes_apt_repository: "deb [signed-by={{ kubernetes_apt_keyring_file }}] https://pkgs.k8s.io/core:/{{ kubernetes_apt_release_channel }}:/v{{ kubernetes_version }}/deb/ /"
+kubernetes_apt_repository: "https://pkgs.k8s.io/core:/{{ kubernetes_apt_release_channel }}:/v{{ kubernetes_version }}/deb/"
 
 kubernetes_yum_base_url: "https://pkgs.k8s.io/core:/stable:/v{{ kubernetes_version }}/rpm/"
 kubernetes_yum_gpg_key: "https://pkgs.k8s.io/core:/stable:/v{{ kubernetes_version }}/rpm/repodata/repomd.xml.key"

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -4,32 +4,22 @@
     name:
       - apt-transport-https
       - ca-certificates
+      - python3-debian
     state: present
-
-- name: Prepare apt keyring directory.
-  ansible.builtin.file:
-    path: "{{ kubernetes_apt_keyring_file | dirname }}"
-    state: directory
-    mode: 0755
-
-- name: Get Kubernetes apt key.
-  ansible.builtin.get_url:
-    url: "https://pkgs.k8s.io/core:/{{ kubernetes_apt_release_channel }}:/v{{ kubernetes_version }}/deb/Release.key"
-    dest: "{{ kubernetes_apt_keyring_file }}"
-    mode: '0644'
-    force: true
-
-- name: Be sure deprecated Kubernetes repository is absent.
-  file:
-    path: "/etc/apt/sources.list.d/apt_kubernetes_io.list"
-    state: absent
 
 - name: Add Kubernetes repository.
-  ansible.builtin.apt_repository:
-    repo: "{{ kubernetes_apt_repository }}"
-    filename: pkgs_k8s_io
-    state: present
+  deb822_repository:
+    name: kubernetes
+    types: deb
+    uris: "{{ kubernetes_apt_repository }}"
+    suites: /
+    signed_by: "{{ kubernetes_apt_repository }}/Release.key"
+  register: kubernetes_repository
+
+- name: Update Apt cache.
+  apt:
     update_cache: true
+  when: kubernetes_repository.changed
 
 - name: Add Kubernetes apt preferences file to pin a version.
   template:


### PR DESCRIPTION
* deb822_repository format

* Add `debian` package to be able to use deb822_repository.

* Revert "Add `debian` package to be able to use deb822_repository."

This reverts commit 054af0d9777ae73ad236395e5edbb3463bcab12d.

* Add `python3-debian` to list of dependencies.

* Update apt cache when Kubernetes repo is added.

* FML

* Code style.

* Removed some unnecessary stuff.

* Just kidding, adding back in the release channel option.

---------